### PR TITLE
feat(state): Add render pipeline and basic triangle drawing.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,10 @@ use winit::event_loop::EventLoop;
 use crate::app::App;
 
 #[cfg(target_arch = "wasm32")]
-const DEFAULT_CANVAS_WIDTH: u32 = 300;
+const DEFAULT_CANVAS_WIDTH: u32 = 800;
 
 #[cfg(target_arch = "wasm32")]
-const DEFAULT_CANVAS_HEIGHT: u32 = 150;
+const DEFAULT_CANVAS_HEIGHT: u32 = 600;
 
 /// Starts the application in native or WASM environments.
 ///

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -1,0 +1,29 @@
+// Vertex shader
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+};
+
+@vertex
+fn vs_main(
+    @builtin(vertex_index) in_vertex_index: u32,
+) -> VertexOutput {
+    var out: VertexOutput;
+
+    let x = f32(1 - i32(in_vertex_index)) * 0.5;
+
+    let y = f32(i32(in_vertex_index & 1u) * 2 - 1) * 0.5;
+
+    out.clip_position = vec4<f32>(x, y, 0.0, 1.0);
+
+    return out;
+}
+
+
+// Fragment shader
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(1.0, 0.0, 1.0, 1.0);
+}
+

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,3 +1,4 @@
+use std::iter;
 use std::sync::Arc;
 use winit::event_loop::ActiveEventLoop;
 use winit::keyboard::KeyCode;
@@ -71,6 +72,11 @@ pub struct State
         ///
         /// We want to store the window in a shared State and pass clones around without worrying about ownership.
         pub window: Arc<Window>,
+
+        /// Handle to a rendering (graphics) pipeline.
+        ///
+        /// Reference <https://gpuweb.github.io/gpuweb/#render-pipeline>
+        pub render_pipeline: wgpu::RenderPipeline,
 
         /// Handle to a presentable surface.
         ///
@@ -217,7 +223,62 @@ impl State
 
                                                      desired_maximum_frame_latency: 2 };
 
+                // Loads the data from the `wgsl` file.
+                let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                        label: Some("Shader"),
+                        source: wgpu::ShaderSource::Wgsl(include_str!("shader.wgsl").into()),
+                });
+
+                let render_pipeline_layout =
+                        device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                        label: Some("Render Pipeline Layout"),
+                        bind_group_layouts: &[],
+                        push_constant_ranges: &[],
+                });
+
+                let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                        label: Some("Render Pipeline"),
+                        layout: Some(&render_pipeline_layout),
+                        vertex: wgpu::VertexState {
+                                module: &shader,
+                                entry_point: Some("vs_main"), // 1.
+                                buffers: &[], // 2.
+                                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                        },
+                        fragment: Some(wgpu::FragmentState { // 3.
+                                module: &shader,
+                                entry_point: Some("fs_main"),
+                                targets: &[Some(wgpu::ColorTargetState { // 4.
+                                        format: config.format,
+                                        blend: Some(wgpu::BlendState::REPLACE),
+                                        write_mask: wgpu::ColorWrites::ALL,
+                                })],
+                                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                        }),
+                        primitive: wgpu::PrimitiveState {
+                                topology: wgpu::PrimitiveTopology::TriangleList, // 1.
+                                strip_index_format: None,
+                                front_face: wgpu::FrontFace::Ccw, // 2.
+                                cull_mode: Some(wgpu::Face::Back),
+                                // Setting this to anything other than Fill requires Features::NON_FILL_POLYGON_MODE
+                                polygon_mode: wgpu::PolygonMode::Fill,
+                                // Requires Features::DEPTH_CLIP_CONTROL
+                                unclipped_depth: false,
+                                // Requires Features::CONSERVATIVE_RASTERIZATION
+                                conservative: false,
+                        },
+                        depth_stencil: None, // 1.
+                                multisample: wgpu::MultisampleState {
+                                        count: 1, // 2.
+                                        mask: !0, // 3.
+                                        alpha_to_coverage_enabled: false, // 4.
+                                },
+                                multiview: None, // 5.
+                                cache: None, // 6.
+                        });
+
                 Ok(State { window,
+                           render_pipeline,
                            surface,
                            device,
                            queue,
@@ -307,45 +368,49 @@ impl State
         {
                 self.window.request_redraw();
 
+                // We can't render unless the surface is configured
                 if !self.is_surface_configured
                 {
                         return Ok(());
                 }
 
                 let output = self.surface.get_current_texture()?;
-
                 let view = output.texture
                                  .create_view(&wgpu::TextureViewDescriptor::default());
-                let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("Render Encoder!"),
-            });
+
+                let mut encoder = self
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                        label: Some("Render Encoder"),
+                });
 
                 {
-                        let _render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                                 label: Some("Render Pass"),
                                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                depth_slice: None,
-                                view: &view,
-                                resolve_target: None,
-                                ops: wgpu::Operations {
-                                        load: wgpu::LoadOp::Clear(wgpu::Color {
-                                                r: 0.1,
-                                                g: 0.2,
-                                                b: 0.3,
-                                                a: 1.0,
-                                        }),
-
-                                store: wgpu::StoreOp::Store,
-                                },
-                        })],
-                        depth_stencil_attachment: None,
-                        occlusion_query_set: None,
-                        timestamp_writes: None,
+                                        view: &view,
+                                        resolve_target: None,
+                                        ops: wgpu::Operations {
+                                                load: wgpu::LoadOp::Clear(wgpu::Color {
+                                                        r: 0.1,
+                                                        g: 0.2,
+                                                        b: 0.3,
+                                                        a: 1.0,
+                                                }),
+                                                store: wgpu::StoreOp::Store,
+                                        },
+                                        depth_slice: None,
+                                })],
+                                depth_stencil_attachment: None,
+                                occlusion_query_set: None,
+                                timestamp_writes: None,
                         });
+
+                        render_pass.set_pipeline(&self.render_pipeline);
+                        render_pass.draw(0..3, 0..1);
                 }
 
-                // submit will accept anything that implements IntoIter
-                self.queue.submit(std::iter::once(encoder.finish()));
+                self.queue.submit(iter::once(encoder.finish()));
                 output.present();
 
                 Ok(())


### PR DESCRIPTION
- Introduced `render_pipeline` field to `State` struct
- Created shader module and pipeline layout
- Configured render pipeline with vertex and fragment stages
- Updated `render` method to set pipeline and draw a triangle
- Increased default WASM canvas size to 800x600