### PR TITLE
feat(instancing): Add per-instance transforms and GPU instancing supp…

### DIFF
--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -1,45 +1,52 @@
-struct CameraUniform
-{
-    	view_proj: mat4x4<f32>,
-};
+// Vertex shader
 
-@group(1) @binding(0) // 1.
-var<uniform> camera: CameraUniform;
+struct Camera {
+    view_proj: mat4x4<f32>,
+}
+@group(1) @binding(0)
+var<uniform> camera: Camera;
 
-struct VertexInput
-{
-    	@location(0) position: vec3<f32>,
-
-    	@location(1) tex_coords: vec2<f32>,
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) tex_coords: vec2<f32>,
+}
+struct InstanceInput {
+    @location(5) model_matrix_0: vec4<f32>,
+    @location(6) model_matrix_1: vec4<f32>,
+    @location(7) model_matrix_2: vec4<f32>,
+    @location(8) model_matrix_3: vec4<f32>,
 }
 
-struct VertexOutput
-{
-    	@builtin(position) clip_position: vec4<f32>,
-
-    	@location(0) tex_coords: vec2<f32>,
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) tex_coords: vec2<f32>,
 }
 
 @vertex
-fn vs_main(model: VertexInput) -> VertexOutput
-{
-   	var out: VertexOutput;
-
-   	out.tex_coords = model.tex_coords;
-
-   	out.clip_position = camera.view_proj * vec4<f32>(model.position, 1.0); // 2.
-
-   	return out;
+fn vs_main(
+    model: VertexInput,
+    instance: InstanceInput,
+) -> VertexOutput {
+    let model_matrix = mat4x4<f32>(
+        instance.model_matrix_0,
+        instance.model_matrix_1,
+        instance.model_matrix_2,
+        instance.model_matrix_3,
+    );
+    var out: VertexOutput;
+    out.tex_coords = model.tex_coords;
+    out.clip_position = camera.view_proj * model_matrix * vec4<f32>(model.position, 1.0);
+    return out;
 }
+
+// Fragment shader
 
 @group(0) @binding(0)
 var t_diffuse: texture_2d<f32>;
-
 @group(0)@binding(1)
 var s_diffuse: sampler;
 
 @fragment
-fn fs_main(in: VertexOutput) -> @location(0) vec4<f32>
-{
-    	return textureSample(t_diffuse, s_diffuse, in.tex_coords);
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(t_diffuse, s_diffuse, in.tex_coords);
 }


### PR DESCRIPTION
…ort.

- Introduce `Instance` and `InstanceRaw` structs to represent per-instance position/rotation and GPU-friendly matrix data
- Implement `InstanceRaw::desc` to define vertex buffer layout for mat4
- Update vertex shader to apply per-instance model matrices
- Add instance buffer creation and binding in `State`
- Render multiple instances with a single draw call
- Center instances in a grid using displacement, with per-instance quaternion rotation